### PR TITLE
Failing test for revoke endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /composer.lock
 /.idea/
 /tests/cli/client.json
+/tests/cli/client-admin.json

--- a/tests/cli/cleanup.php
+++ b/tests/cli/cleanup.php
@@ -7,6 +7,9 @@ use ParagonIE\Chronicle\Chronicle;
 if (file_exists(__DIR__ . '/client.json')) {
     exit(0);
 }
+if (file_exists(__DIR__ . '/client-admin.json')) {
+    exit(0);
+}
 
 require_once __DIR__ . '/cli-include.php';
 
@@ -18,6 +21,14 @@ Chronicle::getDatabase()->delete(
         'publicid' => 'CLI-testing-user'
     ]
 );
+Chronicle::getDatabase()->delete(
+    'chronicle_clients',
+    [
+        'isAdmin' => true,
+        'publicid' => 'CLI-admin-user'
+    ]
+);
 Chronicle::getDatabase()->commit();
 
 unlink(__DIR__.'/client.json');
+unlink(__DIR__.'/client-admin.json');

--- a/tests/cli/command-preamble.php
+++ b/tests/cli/command-preamble.php
@@ -30,6 +30,16 @@ $client = [
     'public-key' => new SigningPublicKey(Base64UrlSafe::decode($clientData['public-key']))
 ];
 
+if (!\is_readable((__DIR__ . '/client-admin.json'))) {
+    echo 'client-admin.json is not found!', PHP_EOL;
+    exit(255);
+}
+$clientAdminData = \json_decode(\file_get_contents(__DIR__ . '/client-admin.json'), true);
+$clientAdmin = [
+    'secret-key' => new SigningSecretKey(Base64UrlSafe::decode($clientAdminData['secret-key'])),
+    'public-key' => new SigningPublicKey(Base64UrlSafe::decode($clientAdminData['public-key']))
+];
+
 /*
 $request = $sapient->createSignedJsonRequest(
     'POST',

--- a/tests/cli/commands/public-endpoints.php
+++ b/tests/cli/commands/public-endpoints.php
@@ -13,6 +13,7 @@ require_once dirname(__DIR__) . '/command-preamble.php';
 /**
  * @global string $baseUrl
  * @global array $client
+ * @global array $clientAdmin
  * @global Client $http
  * @global Sapient $sapient
  * @global SigningPublickey $serverPublicKey


### PR DESCRIPTION
Calling the revoke endpoint seems to result in 500 Internal Server Error. Not sure if I'm doing something wrong on my side, or if it's a bug.