### PR TITLE
Resolve all Chronicle issues in MySQL

### DIFF
--- a/sql/mysql/00-local.sql
+++ b/sql/mysql/00-local.sql
@@ -12,13 +12,13 @@ CREATE INDEX chronicle_clients_clientid_idx ON chronicle_clients(`publicid`);
 
 CREATE TABLE chronicle_chain (
   `id` BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-  `data` TEXT,
+  `data` TEXT NOT NULL,
   `prevhash` VARCHAR(128) NULL,
   `currhash` VARCHAR(128) NOT NULL,
-  `hashstate` TEXT,
-  `summaryhash` VARCHAR(128),
-  `publickey` TEXT,
-  `signature` TEXT,
+  `hashstate` TEXT NOT NULL,
+  `summaryhash` VARCHAR(128) NOT NULL,
+  `publickey` TEXT NOT NULL,
+  `signature` TEXT NOT NULL,
   `created` DATETIME DEFAULT CURRENT_TIMESTAMP,
   INDEX(`prevhash`),
   INDEX(`currhash`),

--- a/sql/mysql/00-local.sql
+++ b/sql/mysql/00-local.sql
@@ -26,3 +26,17 @@ CREATE TABLE chronicle_chain (
   FOREIGN KEY (`prevhash`) REFERENCES chronicle_chain(`currhash`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   UNIQUE(`prevhash`)
 );
+
+-- Prevent all types of update to all fields on the chain
+
+CREATE TRIGGER chronicle_chain_trigger
+BEFORE UPDATE ON chronicle_chain 
+FOR EACH ROW SET  NEW.id = OLD.id,
+                  NEW.data = OLD.data,
+                  NEW.prevhash = OLD.prevhash,
+                  NEW.currhash = OLD.currhash,
+                  NEW.hashstate = OLD.hashstate,
+                  NEW.summaryhash = OLD.summaryhash,
+                  NEW.publickey = OLD.publickey,
+                  NEW.signature = OLD.signature,
+                  NEW.created = OLD.created;

--- a/sql/mysql/00-local.sql
+++ b/sql/mysql/00-local.sql
@@ -4,8 +4,8 @@ CREATE TABLE chronicle_clients (
   `publickey` TEXT,
   `isAdmin` BOOLEAN NOT NULL DEFAULT FALSE,
   `comment` TEXT,
-  `created` DATETIME,
-  `modified` DATETIME
+  `created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `modified` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE NOW()
 );
 
 CREATE INDEX chronicle_clients_clientid_idx ON chronicle_clients(`publicid`);
@@ -13,14 +13,16 @@ CREATE INDEX chronicle_clients_clientid_idx ON chronicle_clients(`publicid`);
 CREATE TABLE chronicle_chain (
   `id` BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
   `data` TEXT,
-  `prevhash` VARCHAR(128) NULL,
-  `currhash` VARCHAR(128),
+  `prevhash` VARCHAR(128) NOT NULL,
+  `currhash` VARCHAR(128) NOT NULL,
   `hashstate` TEXT,
   `summaryhash` VARCHAR(128),
   `publickey` TEXT,
   `signature` TEXT,
-  `created` DATETIME,
-  FOREIGN KEY (`currhash`) REFERENCES chronicle_chain(`prevhash`),
+  `created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX(`prevhash`),
+  INDEX(`currhash`),
+  FOREIGN KEY (`currhash`) REFERENCES chronicle_chain(`prevhash`) ON DELETE RESTRICT,
   UNIQUE(`prevhash`)
 );
 

--- a/sql/mysql/00-local.sql
+++ b/sql/mysql/00-local.sql
@@ -13,7 +13,7 @@ CREATE INDEX chronicle_clients_clientid_idx ON chronicle_clients(`publicid`);
 CREATE TABLE chronicle_chain (
   `id` BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
   `data` TEXT,
-  `prevhash` VARCHAR(128) NOT NULL,
+  `prevhash` VARCHAR(128) NULL,
   `currhash` VARCHAR(128) NOT NULL,
   `hashstate` TEXT,
   `summaryhash` VARCHAR(128),
@@ -22,10 +22,7 @@ CREATE TABLE chronicle_chain (
   `created` DATETIME DEFAULT CURRENT_TIMESTAMP,
   INDEX(`prevhash`),
   INDEX(`currhash`),
-  FOREIGN KEY (`currhash`) REFERENCES chronicle_chain(`prevhash`) ON DELETE RESTRICT,
+  INDEX(`summaryhash`),
+  FOREIGN KEY (`prevhash`) REFERENCES chronicle_chain(`currhash`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   UNIQUE(`prevhash`)
 );
-
-CREATE INDEX chronicle_chain_prevhash_idx ON chronicle_chain(`prevhash`);
-CREATE INDEX chronicle_chain_currhash_idx ON chronicle_chain(`currhash`);
-CREATE INDEX chronicle_chain_summaryhash_idx ON chronicle_chain(`summaryhash`);

--- a/sql/mysql/01-remote.sql
+++ b/sql/mysql/01-remote.sql
@@ -18,19 +18,19 @@ CREATE TABLE chronicle_replication_sources (
 
 CREATE TABLE chronicle_replication_chain (
   `id` BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-  `source` BIGINT UNSIGNED REFERENCES chronicle_replication_sources(`id`),
+  `source` BIGINT UNSIGNED REFERENCES chronicle_replication_sources(`id`) ON DELETE RESTRICT,
   `data` TEXT,
-  `prevhash` VARCHAR(128) NULL,
-  `currhash` VARCHAR(128),
+  `prevhash` VARCHAR(128) NOT NULL,
+  `currhash` VARCHAR(128) NOT NULL,
   `hashstate` TEXT,
   `summaryhash` VARCHAR(128),
   `publickey` TEXT,
   `signature` TEXT,
-  `created` TIMESTAMP,
+  `created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   `replicated` TIMESTAMP NULL,
   INDEX(`prevhash`),
   INDEX(`currhash`),
-  FOREIGN KEY (`currhash`) REFERENCES chronicle_replication_chain(`prevhash`),
+  FOREIGN KEY (`currhash`) REFERENCES chronicle_replication_chain(`prevhash`) ON DELETE RESTRICT,
   UNIQUE(`source`, `prevhash`)
 );
 

--- a/sql/mysql/01-remote.sql
+++ b/sql/mysql/01-remote.sql
@@ -18,9 +18,9 @@ CREATE TABLE chronicle_replication_sources (
 
 CREATE TABLE chronicle_replication_chain (
   `id` BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-  `source` BIGINT UNSIGNED REFERENCES chronicle_replication_sources(`id`) ON DELETE RESTRICT,
+  `source` BIGINT UNSIGNED REFERENCES chronicle_replication_sources(`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   `data` TEXT,
-  `prevhash` VARCHAR(128) NOT NULL,
+  `prevhash` VARCHAR(128) NULL,
   `currhash` VARCHAR(128) NOT NULL,
   `hashstate` TEXT,
   `summaryhash` VARCHAR(128),
@@ -30,7 +30,7 @@ CREATE TABLE chronicle_replication_chain (
   `replicated` TIMESTAMP NULL,
   INDEX(`prevhash`),
   INDEX(`currhash`),
-  FOREIGN KEY (`currhash`) REFERENCES chronicle_replication_chain(`prevhash`) ON DELETE RESTRICT,
+  FOREIGN KEY (`prevhash`) REFERENCES chronicle_replication_chain(`currhash`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   UNIQUE(`source`, `prevhash`)
 );
 


### PR DESCRIPTION
Hi,

I tested Chronicle in MySQL connection and I have some issues, I resolved two of them. But, there are many more needs to collaboration with some guidance.

The current known issues are:

- [x] issue mentioned here #32. **Resolved** by made `datetime` fields filled automatically by MySQL.
- [x] issue `ERROR 1048 (23000): Column 'prevhash' cannot be null`.  **Resolved** at database level by swapping foreign key rule `prevhash` with `currhash`.
- [ ] When Chronicle use MySQL should ignore values for `datetime` fields. [**Not-Resolved**]
- [ ] Revise replica functions. [**Not-Resolved**]

Thanks

