### PR TITLE
Concurrent Chronicles

### DIFF
--- a/bin/install.php
+++ b/bin/install.php
@@ -23,6 +23,10 @@ $localSettings = [
     'database' => [
         'dsn' => 'sqlite:' . $root . '/local/chronicle.sql'
     ],
+    // Map 'channel-name' => 'table_prefix'
+    'instances' => [
+        '' => ''
+    ],
     'publish-new-clients' => true,
     'publish-revoked-clients' => true,
     // The maximum window of opportunity for replay attacks:

--- a/public/index.php
+++ b/public/index.php
@@ -15,7 +15,7 @@ session_start();
 
 // Instantiate the app
 $settings = require CHRONICLE_APP_ROOT . '/src/settings.php';
-\ParagonIE\Chronicle\Chronicle::storeSettings($settings);
+\ParagonIE\Chronicle\Chronicle::storeSettings($settings['settings'] ?? []);
 $app = new \Slim\App($settings);
 
 // Set up dependencies

--- a/src/Chronicle/Chronicle.php
+++ b/src/Chronicle/Chronicle.php
@@ -296,6 +296,17 @@ class Chronicle
     }
 
     /**
+     * Is this a valid name for an instance?
+     *
+     * @param string $name
+     * @return bool
+     */
+    public static function isValidInstanceName(string $name): bool
+    {
+        return (bool) \preg_match('#^[A-Za-z0-9_\-]+$#', $name);
+    }
+
+    /**
      * Store the database object in the Chronicle class.
      *
      * @param EasyDB $db

--- a/src/Chronicle/Exception/AccessDenied.php
+++ b/src/Chronicle/Exception/AccessDenied.php
@@ -6,7 +6,7 @@ namespace ParagonIE\Chronicle\Exception;
  * Class AccessDenied
  * @package ParagonIE\Chronicle\Exception
  */
-class AccessDenied extends \Exception
+class AccessDenied extends BaseException
 {
 
 }

--- a/src/Chronicle/Exception/BaseException.php
+++ b/src/Chronicle/Exception/BaseException.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 namespace ParagonIE\Chronicle\Exception;
 
 /**
- * Class ReplicationSourceNotFound
+ * Class BaseException
  * @package ParagonIE\Chronicle\Exception
  */
-class ReplicationSourceNotFound extends BaseException
+class BaseException extends \Exception
 {
 
 }

--- a/src/Chronicle/Exception/ChainAppendException.php
+++ b/src/Chronicle/Exception/ChainAppendException.php
@@ -6,7 +6,7 @@ namespace ParagonIE\Chronicle\Exception;
  * Class ChainAppendException
  * @package ParagonIE\Chronicle\Exception
  */
-class ChainAppendException extends \Exception
+class ChainAppendException extends BaseException
 {
 
 }

--- a/src/Chronicle/Exception/ClientNotFound.php
+++ b/src/Chronicle/Exception/ClientNotFound.php
@@ -6,7 +6,7 @@ namespace ParagonIE\Chronicle\Exception;
  * Class ClientNotFound
  * @package ParagonIE\Chronicle\Exception
  */
-class ClientNotFound extends \Exception
+class ClientNotFound extends BaseException
 {
 
 }

--- a/src/Chronicle/Exception/FilesystemException.php
+++ b/src/Chronicle/Exception/FilesystemException.php
@@ -6,7 +6,7 @@ namespace ParagonIE\Chronicle\Exception;
  * Class FilesystemException
  * @package ParagonIE\Chronicle\Exception
  */
-class FilesystemException extends \Exception
+class FilesystemException extends BaseException
 {
 
 }

--- a/src/Chronicle/Exception/HTTPException.php
+++ b/src/Chronicle/Exception/HTTPException.php
@@ -6,7 +6,7 @@ namespace ParagonIE\Chronicle\Exception;
  * Class HTTPException
  * @package ParagonIE\Chronicle\Exception
  */
-class HTTPException extends \Exception
+class HTTPException extends BaseException
 {
 
 }

--- a/src/Chronicle/Exception/HashNotFound.php
+++ b/src/Chronicle/Exception/HashNotFound.php
@@ -6,7 +6,7 @@ namespace ParagonIE\Chronicle\Exception;
  * Class HashNotFound
  * @package ParagonIE\Chronicle\Exception
  */
-class HashNotFound extends \Exception
+class HashNotFound extends BaseException
 {
 
 }

--- a/src/Chronicle/Exception/InstanceNotFoundException.php
+++ b/src/Chronicle/Exception/InstanceNotFoundException.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 namespace ParagonIE\Chronicle\Exception;
 
 /**
- * Class ReplicationSourceNotFound
+ * Class InstanceNotFoundException
  * @package ParagonIE\Chronicle\Exception
  */
-class ReplicationSourceNotFound extends BaseException
+class InstanceNotFoundException extends \Exception
 {
 
 }

--- a/src/Chronicle/Exception/InvalidInstanceException.php
+++ b/src/Chronicle/Exception/InvalidInstanceException.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 namespace ParagonIE\Chronicle\Exception;
 
 /**
- * Class ReplicationSourceNotFound
+ * Class InvalidInstanceException
  * @package ParagonIE\Chronicle\Exception
  */
-class ReplicationSourceNotFound extends BaseException
+class InvalidInstanceException extends BaseException
 {
 
 }

--- a/src/Chronicle/Exception/SecurityViolation.php
+++ b/src/Chronicle/Exception/SecurityViolation.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Chronicle\Exception;
  *
  * @package ParagonIE\Chronicle\Exception
  */
-class SecurityViolation extends \Exception
+class SecurityViolation extends BaseException
 {
 
 }

--- a/src/Chronicle/Exception/TargetNotFound.php
+++ b/src/Chronicle/Exception/TargetNotFound.php
@@ -9,7 +9,7 @@ namespace ParagonIE\Chronicle\Exception;
  *
  * @package ParagonIE\Chronicle\Exception
  */
-class TargetNotFound extends \Exception
+class TargetNotFound extends BaseException
 {
 
 }

--- a/src/Chronicle/Handlers/Lookup.php
+++ b/src/Chronicle/Handlers/Lookup.php
@@ -113,7 +113,7 @@ class Lookup implements HandlerInterface
                  publickey,
                  signature
              FROM
-                 chronicle_chain
+                 " . Chronicle::getTableName('chain') . "
              WHERE
                  currhash = ?
                  OR summaryhash = ?
@@ -182,7 +182,7 @@ class Lookup implements HandlerInterface
             "SELECT
                  id
              FROM
-                 chronicle_chain
+                 " . Chronicle::getTableName('chain') . "
              WHERE
                  currhash = ?
                  OR summaryhash = ?
@@ -205,7 +205,7 @@ class Lookup implements HandlerInterface
                  publickey,
                  signature
              FROM
-                 chronicle_chain
+                 " . Chronicle::getTableName('chain') . "
              WHERE
                  id > ?
             ",
@@ -233,7 +233,9 @@ class Lookup implements HandlerInterface
     {
         $chain = [];
         /** @var array<int, array<string, string>> $rows */
-        $rows = Chronicle::getDatabase()->run("SELECT * FROM chronicle_chain ORDER BY id ASC");
+        $rows = Chronicle::getDatabase()->run(
+            "SELECT * FROM " . Chronicle::getTableName('chain') . " ORDER BY id ASC"
+        );
         /** @var array<string, string> $row */
         foreach ($rows as $row) {
             $chain[] = [

--- a/src/Chronicle/Handlers/Register.php
+++ b/src/Chronicle/Handlers/Register.php
@@ -168,17 +168,21 @@ class Register implements HandlerInterface
     {
         $db = Chronicle::getDatabase();
         $now = (new \DateTime())->format(\DateTime::ATOM);
+        $queryString = 'SELECT count(id) FROM ' .
+            Chronicle::getTableName('clients') .
+            ' WHERE publicid = ?';
+
         do {
             try {
                 $clientId = Base64UrlSafe::encode(\random_bytes(24));
             } catch (\Throwable $ex) {
                 throw new SecurityViolation('CSPRNG is broken');
             }
-        } while ($db->exists('SELECT count(id) FROM chronicle_clients WHERE publicid = ?', $clientId));
+        } while ($db->exists($queryString, $clientId));
 
         $db->beginTransaction();
         $db->insert(
-            'chronicle_clients',
+            Chronicle::getTableName('clients'),
             [
                 'publicid' => $clientId,
                 'publickey' => $post['publickey'],

--- a/src/Chronicle/Handlers/Replica.php
+++ b/src/Chronicle/Handlers/Replica.php
@@ -136,7 +136,7 @@ class Replica implements HandlerInterface
                  publickey,
                  signature
              FROM
-                 chronicle_replication_chain
+                 " . Chronicle::getTableName('replication_chain') . "
              WHERE
                  source = ? AND (
                      currhash = ?
@@ -178,7 +178,7 @@ class Replica implements HandlerInterface
                  currhash,
                  summaryhash
              FROM
-                 chronicle_replication_chain
+                 ' . Chronicle::getTableName('replication_chain') . '
              WHERE
                  source = ?
              ORDER BY
@@ -221,7 +221,7 @@ class Replica implements HandlerInterface
                 name,
                 publickey AS serverPublicKey
              FROM
-                chronicle_replication_sources"
+                " . Chronicle::getTableName('replication_sources')
         );
         /**
          * @var int $idx
@@ -272,7 +272,7 @@ class Replica implements HandlerInterface
             "SELECT
                  id
              FROM
-                 chronicle_replication_chain
+                 " . Chronicle::getTableName('replication_chain') . "
              WHERE
                  source = ? AND (
                      currhash = ?
@@ -298,7 +298,7 @@ class Replica implements HandlerInterface
                  publickey,
                  signature
              FROM
-                 chronicle_replication_chain
+                 " . Chronicle::getTableName('replication_chain') . "
              WHERE
                  source = ? AND
                  id > ?
@@ -330,7 +330,7 @@ class Replica implements HandlerInterface
         $chain = [];
         /** @var array<int, array<string, string>> $rows */
         $rows = Chronicle::getDatabase()->run(
-            "SELECT * FROM chronicle_replication_chain WHERE source = ? ORDER BY id ASC",
+            "SELECT * FROM " . Chronicle::getTableName('replication_chain') . " WHERE source = ? ORDER BY id ASC",
             $this->source
         );
         /** @var array<string, string> $row */
@@ -361,7 +361,7 @@ class Replica implements HandlerInterface
     {
         /** @var int $source */
         $source = Chronicle::getDatabase()->cell(
-            "SELECT id FROM chronicle_replication_sources WHERE uniqueid = ?",
+            "SELECT id FROM " . Chronicle::getTableName('replication_sources') . " WHERE uniqueid = ?",
             $uniqueId
         );
         if (!$source) {

--- a/src/Chronicle/Handlers/Revoke.php
+++ b/src/Chronicle/Handlers/Revoke.php
@@ -86,7 +86,7 @@ class Revoke implements HandlerInterface
 
         /** @var bool $found */
         $found = $db->exists(
-            'SELECT count(id) FROM chronicle_clients WHERE publicid = ? AND publickey = ?',
+            'SELECT count(id) FROM ' . Chronicle::getTableName('clients') . ' WHERE publicid = ? AND publickey = ?',
             $post['clientid'],
             $post['publickey']
         );
@@ -99,7 +99,7 @@ class Revoke implements HandlerInterface
         }
         /** @var bool $isAdmin */
         $isAdmin = $db->cell(
-            'SELECT isAdmin FROM chronicle_clients WHERE publicid = ? AND publickey = ?',
+            'SELECT isAdmin FROM ' . Chronicle::getTableName('clients') . ' WHERE publicid = ? AND publickey = ?',
             $post['clientid'],
             $post['publickey']
         );
@@ -112,7 +112,7 @@ class Revoke implements HandlerInterface
         }
 
         $db->delete(
-            'chronicle_clients',
+            Chronicle::getTableName('clients'),
             [
                 'publicid' => $post['clientid'],
                 'publickey' => $post['publickey'],
@@ -123,7 +123,9 @@ class Revoke implements HandlerInterface
             // Confirm deletion:
             $result = [
                 'deleted' => !$db->exists(
-                    'SELECT count(id) FROM chronicle_clients WHERE publicid = ? AND publickey = ?',
+                    'SELECT count(id) FROM ' .
+                    Chronicle::getTableName('clients') .
+                    ' WHERE publicid = ? AND publickey = ?',
                     $post['clientid'],
                     $post['publickey']
                 )

--- a/src/Chronicle/Process/CrossSign.php
+++ b/src/Chronicle/Process/CrossSign.php
@@ -101,7 +101,7 @@ class CrossSign
     {
         $db = Chronicle::getDatabase();
         /** @var array<string, string> $data */
-        $data = $db->row('SELECT * FROM chronicle_xsign_targets WHERE id = ?', $id);
+        $data = $db->row('SELECT * FROM ' . Chronicle::getTableName('xsign_targets') . ' WHERE id = ?', $id);
         if (empty($data)) {
             throw new TargetNotFound('Cross-sign target not found');
         }
@@ -140,7 +140,7 @@ class CrossSign
 
         if (isset($this->policy['push-after'])) {
             /** @var int $head */
-            $head = $db->cell('SELECT MAX(id) FROM chronicle_chain');
+            $head = $db->cell('SELECT MAX(id) FROM ' . Chronicle::getTableName('chain'));
             // Only run if we've had more than N entries
             if (($head - (int) ($this->lastRun['id'])) >= $this->policy['push-after']) {
                 return true;
@@ -233,7 +233,7 @@ class CrossSign
     protected function getEndOfChain(EasyDB $db): array
     {
         /** @var array<string, string> $last */
-        $last = $db->row('SELECT * FROM chronicle_chain ORDER BY id DESC LIMIT 1');
+        $last = $db->row('SELECT * FROM ' . Chronicle::getTableName('chain') . ' ORDER BY id DESC LIMIT 1');
         if (empty($last)) {
             return [];
         }
@@ -253,7 +253,7 @@ class CrossSign
     {
         $db->beginTransaction();
         $db->update(
-            'chronicle_xsign_targets',
+            Chronicle::getTableName('xsign_targets'),
             [
                 'lastrun' => \json_encode([
                     'id' => $message['id'],

--- a/src/Chronicle/Process/Replicate.php
+++ b/src/Chronicle/Process/Replicate.php
@@ -85,7 +85,7 @@ class Replicate
     {
         /** @var array<string, string> $row */
         $row = Chronicle::getDatabase()->row(
-            "SELECT * FROM chronicle_replication_sources WHERE id = ?",
+            "SELECT * FROM " . Chronicle::getTableName('replication_sources') . " WHERE id = ?",
             $id
         );
         if (empty($row)) {
@@ -140,7 +140,7 @@ class Replicate
                  currhash,
                  hashstate
              FROM
-                 chronicle_replication_chain
+                 ' . Chronicle::getTableName('replication_chain') . '
              WHERE
                  source = ?
              ORDER BY id DESC
@@ -191,7 +191,7 @@ class Replicate
         }
 
         /* Enter the new row to the replication table */
-        $db->insert('chronicle_replication_chain', [
+        $db->insert(Chronicle::getTableName('replication_chain'), [
             'source' => $this->id,
             'data' => $entry['contents'],
             'prevhash' => $prevhash,
@@ -218,7 +218,7 @@ class Replicate
             "SELECT
                  summaryhash
              FROM
-                 chronicle_replication_chain
+                 " . Chronicle::getTableName('replication_chain') . "
              WHERE
                  source = ?
              ORDER BY id DESC

--- a/src/database.php
+++ b/src/database.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
+use ParagonIE\Chronicle\Chronicle;
+use ParagonIE\Chronicle\Exception\InstanceNotFoundException;
+
 if (!\is_readable(CHRONICLE_APP_ROOT . '/local/settings.json')) {
     echo 'Settings are not loaded.', PHP_EOL;
     exit(1);
@@ -19,5 +22,20 @@ $db = \ParagonIE\EasyDB\Factory::create(
     (array) ($settings['database']['options'] ?? [])
 );
 
-\ParagonIE\Chronicle\Chronicle::setDatabase($db);
+if (!empty($_GET['instance'])) {
+    try {
+        if (\is_string($_GET['instance'])) {
+            /** @var string $instance */
+            $instance = $_GET['instance'];
+            if (\array_key_exists($instance, $settings['instances'])) {
+                Chronicle::setTablePrefix($settings['instances'][$instance]);
+            }
+        }
+    } catch (InstanceNotFoundException $ex) {
+        echo $ex->getMessage(), PHP_EOL;
+        exit(1);
+    }
+}
+
+Chronicle::setDatabase($db);
 return $db;

--- a/src/database.php
+++ b/src/database.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 use ParagonIE\Chronicle\Chronicle;
-use ParagonIE\Chronicle\Exception\InstanceNotFoundException;
 
 if (!\is_readable(CHRONICLE_APP_ROOT . '/local/settings.json')) {
     echo 'Settings are not loaded.', PHP_EOL;
@@ -23,17 +22,12 @@ $db = \ParagonIE\EasyDB\Factory::create(
 );
 
 if (!empty($_GET['instance'])) {
-    try {
-        if (\is_string($_GET['instance'])) {
-            /** @var string $instance */
-            $instance = $_GET['instance'];
-            if (\array_key_exists($instance, $settings['instances'])) {
-                Chronicle::setTablePrefix($settings['instances'][$instance]);
-            }
+    if (\is_string($_GET['instance'])) {
+        /** @var string $instance */
+        $instance = $_GET['instance'];
+        if (\array_key_exists($instance, $settings['instances'])) {
+            Chronicle::setTablePrefix($settings['instances'][$instance]);
         }
-    } catch (InstanceNotFoundException $ex) {
-        echo $ex->getMessage(), PHP_EOL;
-        exit(1);
     }
 }
 

--- a/src/database.php
+++ b/src/database.php
@@ -25,8 +25,10 @@ if (!empty($_GET['instance'])) {
     if (\is_string($_GET['instance'])) {
         /** @var string $instance */
         $instance = $_GET['instance'];
-        if (\array_key_exists($instance, $settings['instances'])) {
-            Chronicle::setTablePrefix($settings['instances'][$instance]);
+        if (Chronicle::isValidInstanceName($instance)) {
+            if (\array_key_exists($instance, $settings['instances'])) {
+                Chronicle::setTablePrefix($settings['instances'][$instance]);
+            }
         }
     }
 }

--- a/tests/cli/cli-include.php
+++ b/tests/cli/cli-include.php
@@ -43,7 +43,7 @@ Chronicle::setDatabase($db);
 $getopt = new GetOpt([
     new Option(null, 'base-url', GetOpt::REQUIRED_ARGUMENT)
 ]);
-$getopt->parse();
+$getopt->process();
 $baseUrl = $getopt->getOption('base-url') ?? 'http://localhost:8080';
 
 $http = new Client();


### PR DESCRIPTION
Add support for multiple instances via the ?instance=name parameter.

To implement, add something like this to your local/settings.json in the
instances key:

    "public_prefix": "table_name_prefix",

Then run bin/make-tables.php as normal.

Every instance is totally independent of each other. They have their own

* Clients
* Chain data
* Cross-Signing Targets and Policies
* Replications

If merged, I will document these features and roll it into v1.1.0. Closes #27.