### PR TITLE
Add pagination to export endpoint API

### DIFF
--- a/bin/create-client.php
+++ b/bin/create-client.php
@@ -113,13 +113,9 @@ try {
 /** @var string $newPublicId */
 $newPublicId = Base64UrlSafe::encode(\random_bytes(24));
 
-// Disable escaping for SQLite
-/** @var boolean $isSQLite */
-$isSQLite = strpos($settings['database']['dsn'] ?? '', 'sqlite:') !== false;
-
 $db->beginTransaction();
 $db->insert(
-    Chronicle::getTableName('clients', $isSQLite),
+    Chronicle::getTableName('clients', true),
     [
         'isAdmin' => !empty($admin),
         'publicid' => $newPublicId,

--- a/sql/pgsql/00-local.sql
+++ b/sql/pgsql/00-local.sql
@@ -4,24 +4,26 @@ CREATE TABLE chronicle_clients (
   publickey TEXT,
   "isAdmin" BOOLEAN NOT NULL DEFAULT FALSE,
   comment TEXT,
-  created TIMESTAMP,
-  modified TIMESTAMP
+  created TIMESTAMP default current_timestamp,
+  modified TIMESTAMP default current_timestamp
 );
 
 CREATE INDEX chronicle_clients_clientid_idx ON chronicle_clients(publicid);
 
 CREATE TABLE chronicle_chain (
   id BIGSERIAL PRIMARY KEY,
-  data TEXT,
+  data TEXT NOT NULL,
   prevhash TEXT NULL,
-  currhash TEXT,
-  hashstate TEXT,
-  summaryhash TEXT,
-  publickey TEXT,
-  signature TEXT,
-  created TIMESTAMP,
-  FOREIGN KEY (currhash) REFERENCES chronicle_chain(prevhash),
-  UNIQUE(prevhash)
+  currhash TEXT NOT NULL,
+  hashstate TEXT NOT NULL,
+  summaryhash TEXT NOT NULL,
+  publickey TEXT NOT NULL,
+  signature TEXT NOT NULL,
+  created TIMESTAMP default current_timestamp,
+  UNIQUE(prevhash),
+  UNIQUE(currhash),
+  UNIQUE(summaryhash),
+  FOREIGN KEY (prevhash) REFERENCES chronicle_chain(currhash)
 );
 
 CREATE INDEX chronicle_chain_prevhash_idx ON chronicle_chain(prevhash);

--- a/sql/pgsql/01-remote.sql
+++ b/sql/pgsql/01-remote.sql
@@ -21,14 +21,14 @@ CREATE TABLE chronicle_replication_chain (
   source BIGINT REFERENCES chronicle_replication_sources(id),
   data TEXT,
   prevhash TEXT NULL,
-  currhash TEXT,
+  currhash TEXT REFERENCES chronicle_replication_chain(prevhash),
   hashstate TEXT,
   summaryhash TEXT,
   publickey TEXT,
   signature TEXT,
-  created TIMESTAMP,
-  replicated TIMESTAMP,
-  FOREIGN KEY (currhash) REFERENCES chronicle_replication_chain(prevhash),
+  created TIMESTAMP default current_timestamp,
+  replicated TIMESTAMP default current_timestamp,
+  UNIQUE(prevhash),
   UNIQUE(source, prevhash)
 );
 

--- a/src/Chronicle/Handlers/Lookup.php
+++ b/src/Chronicle/Handlers/Lookup.php
@@ -269,13 +269,24 @@ class Lookup implements HandlerInterface
         $offset = ($currentPage - 1) * $perPage;
         $totalPages = ceil($totalRows / $perPage);
 
+        if($offset < 0){
+            $offset = 0;
+        }
+
+        // PostreSQL has a different structure for Pagination.
+        // But, MySQL and SQLite behave similar to each other.
+        /** @var string $paginationCondition */
+        $paginationCondition = Chronicle::getDatabase()->getDriver() === 'pgsql' ?
+            "LIMIT {$perPage} OFFSET {$offset}"
+            :
+            "LIMIT {$offset}, {$perPage}";
+
         /** @var array<int, array<string, string>> $rows */
         $rows = Chronicle::getDatabase()->run(
             "SELECT *
              FROM " . Chronicle::getTableName('chain') . "
              ORDER BY id ASC
-             LIMIT {$offset}, {$perPage}
-            "
+            " . $paginationCondition
         );
         /** @var array<string, string> $row */
         foreach ($rows as $row) {

--- a/src/Chronicle/Handlers/Lookup.php
+++ b/src/Chronicle/Handlers/Lookup.php
@@ -253,7 +253,7 @@ class Lookup implements HandlerInterface
         /** @var int $currentPage */
         $currentPage = (int) ($_GET['page'] ?? $page ?? 1);
 
-        /** @var array<int, array<string, string>> $total */
+        /** @var array<int, array<string, string>> $statistic */
         $statistic = Chronicle::getDatabase()->row(
             "SELECT COUNT(*) as total
              FROM " . Chronicle::getTableName('chain')


### PR DESCRIPTION
#34 **Feature Fulfilled**.

By default `chronicle/export` will return first page with rule limited to 5 rows per page.

`http://localhost:8080/chronicle/export?page=4`

Here is the new output:

```json

{
    "version": "1.1.x",
    "datetime": "2019-02-01T08:48:29+00:00",
    "status": "OK",
    "results": {
        "data": [
            {
                "contents": "{\n    \"date\": \"2019-01-31T19:14:08+00:00\",\n    \"body\": {\n        \"test_5c534900c25ba\": \"salam 1548962048.7961 world!\"\n    }\n}",
                "prev": "P1ZuB6gelMqp3qAVYcY1OQwyCvV5jkgkqLrh0wRq1vk=",
                "hash": "9X_0VB24CfCxLcsFxXGxIFJCr-YgJi8qy8hsSgoiGrQ=",
                "summary": "9N2lIBBVjoltx8EPwIGp25QiDyPyPXx1UkZ56cyRjJw=",
                "created": "2019-01-31T19:14:09+00:00",
                "publickey": "I-KUjChzI2krmTNOF7BEpO6KUTWznqmi7qVaJ_-56b4=",
                "signature": "HZ1YqT3LQ09krMPy8tN-JIVFrNOiHgdooFxCnWlvJsoMg87uhL5AArFCtimADadgBIXqeZ5qaCbfo4p18m3oBw=="
            }
        ],
        "meta": {
            "current_page": 4,
            "per_page": 5,
            "total_pages": 4,
            "total_rows": 16
        }
    }
}
```

### Testing:

- [x] SQLite.
- [x] MySQL.
- [x] PostgreSQL.

Thanks